### PR TITLE
Timer didn't support units smaller then microsecand

### DIFF
--- a/aiomeasures/clients/bases.py
+++ b/aiomeasures/clients/bases.py
@@ -97,5 +97,5 @@ class Timer:
         self._started = perf_counter()
 
     def stop(self):
-        value = int((perf_counter() - self._started) * 1000)
+        value = (perf_counter() - self._started) * 1000
         self.client.timing(self.name, value, rate=self.rate, tags=self.tags)


### PR DESCRIPTION
using int on pref_counter() output, was causing unit smaller then microsecond not to be report at all.
we are better off with a fraction, and then handling it on the dashboard level (grafana + promitius in my case)